### PR TITLE
Consensus app updates

### DIFF
--- a/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
@@ -18,6 +18,11 @@ contract ConsensusApp {
     uint numParticipants = _old.participants.length;
 
     // Commitment validations
+    if (oldCommitment.updateType == ConsensusCommitment.UpdateType.Proposal) {
+      validateProposeCommitment(oldCommitment);
+    } else if (oldCommitment.updateType == ConsensusCommitment.UpdateType.Consensus) {
+      validateConsensusCommitment(oldCommitment);
+    }
     if (newCommitment.updateType == ConsensusCommitment.UpdateType.Proposal) {
       validateProposeCommitment(newCommitment);
     } else if (newCommitment.updateType == ConsensusCommitment.UpdateType.Consensus) {

--- a/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
@@ -130,7 +130,7 @@ contract ConsensusApp {
 
   // Commitment validations
 
-  function validConsensusState(
+  function validateConsensusCommitment(
     ConsensusCommitment.ConsensusCommitmentStruct memory commitment
   ) private pure {
     require(
@@ -146,7 +146,8 @@ contract ConsensusApp {
       "ConsensusApp: 'proposedDestination' must be reset during consensus."
     ); 
   } 
-  function validProposeState(
+
+  function validateProposeCommitment(
     ConsensusCommitment.ConsensusCommitmentStruct memory commitment
   ) private pure {
     require(

--- a/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
@@ -123,6 +123,10 @@ contract ConsensusApp {
 
   modifier validConsensusState(ConsensusCommitment.ConsensusCommitmentStruct memory commitment) {
     require(
+      commitment.furtherVotesRequired == 0,
+      "ConsensusApp: 'furtherVotesRequired' must be 0 during consensus."
+      ); 
+    require(
       commitment.proposedAllocation.length == 0,
       "ConsensusApp: 'proposedAllocation' must be reset during consensus."
       ); 

--- a/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/ConsensusApp.sol
@@ -136,6 +136,21 @@ contract ConsensusApp {
     ); 
     _;
   } 
+  modifier validProposeState(ConsensusCommitment.ConsensusCommitmentStruct memory commitment) {
+    require(
+      commitment.furtherVotesRequired != 0,
+      "ConsensusApp: 'furtherVotesRequired' must not be 0 during propose."
+      ); 
+    require(
+      commitment.proposedAllocation.length > 0,
+      "ConsensusApp: 'proposedAllocation' must not be empty during propose."
+      ); 
+    require(
+      commitment.proposedDestination.length == commitment.proposedAllocation.length,
+      "ConsensusApp: 'proposedDestination' and 'proposedAllocation' must be the same length during propose."
+    ); 
+    _;
+  } 
 
 // transition validations
 
@@ -145,6 +160,7 @@ contract ConsensusApp {
   ) private pure
     balancesUnchanged(oldCommitment, newCommitment)
     proposalsUnchanged(oldCommitment, newCommitment)
+    validProposeState(newCommitment)
   { }
 
   function validatePropose(
@@ -154,6 +170,7 @@ contract ConsensusApp {
   ) private pure
     balancesUnchanged(oldCommitment, newCommitment)
     furtherVotesRequiredInitialized(newCommitment, numParticipants)
+    validProposeState(newCommitment)
   { }
 
   function validateFinalVote(

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -157,6 +157,10 @@ export function pass(commitment: ConsensusReachedCommitment): ConsensusReachedCo
 }
 
 export function vote(commitment: ProposalCommitment): ProposalCommitment {
+  if (commitment.appAttributes.furtherVotesRequired <= 1) {
+    throw new Error('Invalid input -- furtherVotesRequired must be greater than 1');
+  }
+
   return {
     ...commitment,
     turnNum: commitment.turnNum + 1,
@@ -168,6 +172,10 @@ export function vote(commitment: ProposalCommitment): ProposalCommitment {
 }
 
 export function finalVote(commitment: ProposalCommitment): ConsensusReachedCommitment {
+  if (commitment.appAttributes.furtherVotesRequired !== 1) {
+    throw new Error('Invalid input -- furtherVotesRequired must be 1');
+  }
+
   return {
     ...commitment,
     turnNum: commitment.turnNum + 1,

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -109,6 +109,14 @@ export function asCoreCommitment(c: ConsensusCommitment): Commitment {
 }
 
 // Transition helper functions
+
+const consensusAtts: () => ConsensusAppAttrs = () => ({
+  proposedAllocation: [],
+  proposedDestination: [],
+  updateType: UpdateType.Consensus,
+  furtherVotesRequired: 0,
+});
+
 export function initialConsensus(c: {
   channel: Channel;
   turnNum: number;
@@ -119,12 +127,7 @@ export function initialConsensus(c: {
   return {
     ...c,
     commitmentType: CommitmentType.App,
-    appAttributes: {
-      proposedAllocation: [],
-      proposedDestination: [],
-      updateType: UpdateType.Consensus,
-      furtherVotesRequired: 0,
-    },
+    appAttributes: consensusAtts(),
   };
 }
 export function propose(
@@ -149,10 +152,7 @@ export function pass(commitment: ConsensusReachedCommitment): ConsensusReachedCo
   return {
     ...commitment,
     turnNum: commitment.turnNum + 1,
-    appAttributes: {
-      ...commitment.appAttributes,
-      updateType: UpdateType.Consensus,
-    },
+    appAttributes: consensusAtts(),
   };
 }
 
@@ -173,13 +173,7 @@ export function finalVote(commitment: ProposalCommitment): ConsensusReachedCommi
     turnNum: commitment.turnNum + 1,
     allocation: commitment.appAttributes.proposedAllocation,
     destination: commitment.appAttributes.proposedDestination,
-    appAttributes: {
-      ...commitment.appAttributes,
-      updateType: UpdateType.Consensus,
-      proposedAllocation: [],
-      proposedDestination: [],
-      furtherVotesRequired: 0,
-    },
+    appAttributes: consensusAtts(),
   };
 }
 
@@ -187,12 +181,7 @@ export function veto(commitment: ProposalCommitment): ConsensusReachedCommitment
   return {
     ...commitment,
     turnNum: commitment.turnNum + 1,
-    appAttributes: {
-      ...commitment.appAttributes,
-      updateType: UpdateType.Consensus,
-      proposedAllocation: [],
-      proposedDestination: [],
-    },
+    appAttributes: consensusAtts(),
   };
 }
 
@@ -201,12 +190,14 @@ export function proposeAlternative(
   proposedAllocation: Uint256[],
   proposedDestination: Address[],
 ): ProposalCommitment {
+  const numParticipants = commitment.channel.participants.length;
+
   return {
     ...commitment,
     turnNum: commitment.turnNum + 1,
     appAttributes: {
-      ...commitment.appAttributes,
       updateType: UpdateType.Proposal,
+      furtherVotesRequired: numParticipants - 1,
       proposedAllocation,
       proposedDestination,
     },

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -68,7 +68,9 @@ export function isAppCommitment(c: ConsensusBaseCommitment): c is AppCommitment 
   return isProposal(c) || isConsensusReached(c);
 }
 
-export function appAttributes(ethersAppAttrs: [string, string[], string[], string]): AppAttributes {
+export function appAttributes(
+  ethersAppAttrs: [string, string[], string[], string],
+): ConsensusAppAttrs | ProposalAppAttrs {
   return {
     furtherVotesRequired: parseInt(ethersAppAttrs[0], 10),
     proposedAllocation: ethersAppAttrs[1].map(bigNumberify).map(bn => bn.toHexString()),
@@ -95,7 +97,7 @@ export function bytesFromAppAttributes(appAttrs: AppAttributes): Bytes {
   ]);
 }
 
-export function appAttributesFromBytes(appAttrs: Bytes): AppAttributes {
+export function appAttributesFromBytes(appAttrs: Bytes): ConsensusAppAttrs | ProposalAppAttrs {
   return appAttributes(abi.decodeParameter(SolidityConsensusCommitmentType, appAttrs));
 }
 

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -38,7 +38,24 @@ export interface ConsensusReachedCommitment extends ConsensusBaseCommitment {
   updateType: UpdateType.Consensus;
 }
 
-function preFundSetupCommitment(opts: ConsensusBaseCommitment) {
+export interface PreFundSetupCommitment extends ConsensusBaseCommitment {
+  commitmentType: CommitmentType.PreFundSetup;
+}
+export interface PostFundSetupCommitment extends ConsensusBaseCommitment {
+  commitmentType: CommitmentType.PostFundSetup;
+}
+export type AppCommitment = ProposalCommitment | ConsensusReachedCommitment;
+export interface ConcludeCommitment extends ConsensusBaseCommitment {
+  commitmentType: CommitmentType.Conclude;
+}
+
+export type ConsensusCommitment =
+  | PreFundSetupCommitment
+  | AppCommitment
+  | PostFundSetupCommitment
+  | ConcludeCommitment;
+
+function preFundSetupCommitment(opts: ConsensusBaseCommitment): Commitment {
   return {
     ...opts,
     commitmentType: CommitmentType.PreFundSetup,
@@ -46,7 +63,7 @@ function preFundSetupCommitment(opts: ConsensusBaseCommitment) {
   };
 }
 
-function postFundSetupCommitment(opts: ConsensusBaseCommitment) {
+function postFundSetupCommitment(opts: ConsensusBaseCommitment): Commitment {
   return {
     ...opts,
     commitmentType: CommitmentType.PostFundSetup,
@@ -54,7 +71,7 @@ function postFundSetupCommitment(opts: ConsensusBaseCommitment) {
   };
 }
 
-function appCommitment(opts: ConsensusBaseCommitment) {
+function appCommitment(opts: ConsensusBaseCommitment): Commitment {
   return {
     ...opts,
     commitmentType: CommitmentType.App,
@@ -62,7 +79,7 @@ function appCommitment(opts: ConsensusBaseCommitment) {
   };
 }
 
-function concludeCommitment(opts: ConsensusBaseCommitment) {
+function concludeCommitment(opts: ConsensusBaseCommitment): Commitment {
   return {
     ...opts,
     commitmentType: CommitmentType.Conclude,

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -176,6 +176,7 @@ export function finalVote(commitment: ProposalCommitment): ConsensusReachedCommi
       updateType: UpdateType.Consensus,
       proposedAllocation: [],
       proposedDestination: [],
+      furtherVotesRequired: 0,
     },
   };
 }

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -36,12 +36,10 @@ export interface ProposalCommitment extends ConsensusBaseCommitment {
   commitmentType: CommitmentType.App;
   appAttributes: ProposalAppAttrs;
 }
-
 export interface ConsensusReachedCommitment extends ConsensusBaseCommitment {
   commitmentType: CommitmentType.App;
   appAttributes: ConsensusAppAttrs;
 }
-
 export interface PreFundSetupCommitment extends ConsensusBaseCommitment {
   commitmentType: CommitmentType.PreFundSetup;
 }
@@ -58,6 +56,17 @@ export type ConsensusCommitment =
   | AppCommitment
   | PostFundSetupCommitment
   | ConcludeCommitment;
+
+// Type guards
+export function isProposal(c: ConsensusBaseCommitment): c is ProposalCommitment {
+  return c.appAttributes.updateType === UpdateType.Proposal;
+}
+export function isConsensusReached(c: ConsensusBaseCommitment): c is ConsensusReachedCommitment {
+  return c.appAttributes.updateType === UpdateType.Consensus;
+}
+export function isAppCommitment(c: ConsensusBaseCommitment): c is AppCommitment {
+  return isProposal(c) || isConsensusReached(c);
+}
 
 export function appAttributes(ethersAppAttrs: [string, string[], string[], string]): AppAttributes {
   return {

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -212,3 +212,5 @@ export function proposeAlternative(
     },
   };
 }
+
+export { validTransition } from './validTransition';

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -209,10 +209,3 @@ export function proposeAlternative(
     },
   };
 }
-
-export function validTransition(
-  fromCommitment: AppCommitment,
-  toCommitment: AppCommitment,
-): boolean {
-  return !!fromCommitment && !!toCommitment;
-}

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -55,45 +55,6 @@ export type ConsensusCommitment =
   | PostFundSetupCommitment
   | ConcludeCommitment;
 
-function preFundSetupCommitment(opts: ConsensusBaseCommitment): Commitment {
-  return {
-    ...opts,
-    commitmentType: CommitmentType.PreFundSetup,
-    appAttributes: bytesFromAppAttributes(opts),
-  };
-}
-
-function postFundSetupCommitment(opts: ConsensusBaseCommitment): Commitment {
-  return {
-    ...opts,
-    commitmentType: CommitmentType.PostFundSetup,
-    appAttributes: bytesFromAppAttributes(opts),
-  };
-}
-
-function appCommitment(opts: ConsensusBaseCommitment): Commitment {
-  return {
-    ...opts,
-    commitmentType: CommitmentType.App,
-    appAttributes: bytesFromAppAttributes(opts),
-  };
-}
-
-function concludeCommitment(opts: ConsensusBaseCommitment): Commitment {
-  return {
-    ...opts,
-    commitmentType: CommitmentType.Conclude,
-    appAttributes: bytesFromAppAttributes(opts),
-  };
-}
-
-export const commitments = {
-  preFundSetupCommitment,
-  postFundSetupCommitment,
-  appCommitment,
-  concludeCommitment,
-};
-
 export function appAttributes(ethersAppAttrs: [string, string[], string[], string]): AppAttributes {
   return {
     furtherVotesRequired: parseInt(ethersAppAttrs[0], 10),

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -94,14 +94,12 @@ export const commitments = {
   concludeCommitment,
 };
 
-export function appAttributes(
-  consensusCommitmentArgs: [string, string[], string[], string],
-): AppAttributes {
+export function appAttributes(ethersAppAttrs: [string, string[], string[], string]): AppAttributes {
   return {
-    furtherVotesRequired: parseInt(consensusCommitmentArgs[0], 10),
-    proposedAllocation: consensusCommitmentArgs[1].map(bigNumberify).map(bn => bn.toHexString()),
-    proposedDestination: consensusCommitmentArgs[2],
-    updateType: parseInt(consensusCommitmentArgs[3], 10),
+    furtherVotesRequired: parseInt(ethersAppAttrs[0], 10),
+    proposedAllocation: ethersAppAttrs[1].map(bigNumberify).map(bn => bn.toHexString()),
+    proposedDestination: ethersAppAttrs[2],
+    updateType: parseInt(ethersAppAttrs[3], 10),
   };
 }
 

--- a/packages/fmg-nitro-adjudicator/src/consensus-app.ts
+++ b/packages/fmg-nitro-adjudicator/src/consensus-app.ts
@@ -209,3 +209,10 @@ export function proposeAlternative(
     },
   };
 }
+
+export function validTransition(
+  fromCommitment: AppCommitment,
+  toCommitment: AppCommitment,
+): boolean {
+  return !!fromCommitment && !!toCommitment;
+}

--- a/packages/fmg-nitro-adjudicator/src/validTransition.ts
+++ b/packages/fmg-nitro-adjudicator/src/validTransition.ts
@@ -1,0 +1,138 @@
+import { AppCommitment, isConsensusReached, isProposal } from './consensus-app';
+export function validTransition(fromCommitment: AppCommitment, toCommitment: AppCommitment): true {
+  // State; machine; transition; identifier;
+  if (isConsensusReached(fromCommitment)) {
+    if (isProposal(toCommitment)) {
+      validatePropose(fromCommitment, toCommitment);
+      return true;
+    }
+    if (isConsensusReached(toCommitment)) {
+      validatePass(fromCommitment, toCommitment);
+      return true;
+    }
+  }
+  if (isProposal(fromCommitment)) {
+    if (isProposal(toCommitment)) {
+      if (hasFurtherVotesNeededBeenInitialized(toCommitment)) {
+        validatePropose(fromCommitment, toCommitment);
+        return true;
+      } else {
+        validateVote(fromCommitment, toCommitment);
+        return true;
+      }
+    }
+    if (isConsensusReached(toCommitment)) {
+      if (haveBalancesBeenUpdated(fromCommitment, toCommitment)) {
+        validateFinalVote(fromCommitment, toCommitment);
+        return true;
+      } else {
+        validateVeto(fromCommitment, toCommitment);
+        return true;
+      }
+    }
+  }
+  throw new Error('ConsensusApp: No valid transition found for commitments');
+}
+
+function validatePass(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  balancesUnchanged(fromCommitment, toCommitment);
+  proposalsUnchanged(fromCommitment, toCommitment);
+}
+function validatePropose(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  balancesUnchanged(fromCommitment, toCommitment);
+  furtherVotesRequiredInitialized(toCommitment);
+}
+function validateFinalVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  validConsensusState(toCommitment);
+  balancesUpdated(fromCommitment, toCommitment);
+}
+function validateVeto(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  balancesUnchanged(fromCommitment, toCommitment);
+  validConsensusState(toCommitment);
+}
+function validateVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  balancesUnchanged(fromCommitment, toCommitment);
+  proposalsUnchanged(fromCommitment, toCommitment);
+  furtherVotesRequiredDecremented(fromCommitment, toCommitment);
+}
+// helpers
+function haveBalancesBeenUpdated(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  return (
+    fromCommitment.appAttributes.proposedAllocation === toCommitment.allocation &&
+    fromCommitment.appAttributes.proposedDestination === toCommitment.destination
+  );
+}
+function hasFurtherVotesNeededBeenInitialized(commitment: AppCommitment): boolean {
+  const numParticipants = commitment.channel.participants.length;
+  return commitment.appAttributes.furtherVotesRequired === numParticipants - 1;
+}
+
+// modifiers
+function balancesUpdated(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  if (!(fromCommitment.appAttributes.proposedAllocation === toCommitment.allocation)) {
+    throw new Error("ConsensusApp: 'allocation' must be set to the previous `proposedAllocation`.");
+  }
+
+  if (!(fromCommitment.appAttributes.proposedDestination === toCommitment.destination)) {
+    throw new Error(
+      "ConsensusApp: 'destination' must be set to the previous `proposedDestination`",
+    );
+  }
+}
+function balancesUnchanged(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  if (!(fromCommitment.allocation === toCommitment.allocation)) {
+    throw new Error("ConsensusApp: 'allocation' must be the same between commitments.");
+  }
+
+  if (!(fromCommitment.destination === toCommitment.destination)) {
+    throw new Error("ConsensusApp: 'destination' must be the same between commitments.");
+  }
+}
+function proposalsUnchanged(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  if (
+    !(
+      fromCommitment.appAttributes.proposedAllocation ===
+      toCommitment.appAttributes.proposedAllocation
+    )
+  ) {
+    throw new Error("ConsensusApp: 'proposedAllocation' must be the same between commitments.");
+  }
+  if (
+    !(
+      fromCommitment.appAttributes.proposedDestination ===
+      toCommitment.appAttributes.proposedDestination
+    )
+  ) {
+    throw new Error("ConsensusApp: 'proposedDestination' must be the same between commitments.");
+  }
+}
+function furtherVotesRequiredInitialized(commitment: AppCommitment) {
+  const numParticipants = commitment.channel.participants.length;
+  if (!(commitment.appAttributes.furtherVotesRequired === numParticipants - 1)) {
+    throw new Error(
+      'Consensus App: furtherVotesRequired needs to be initialized to the correct value.',
+    );
+  }
+}
+function furtherVotesRequiredDecremented(
+  fromCommitment: AppCommitment,
+  toCommitment: AppCommitment,
+) {
+  if (
+    !(
+      toCommitment.appAttributes.furtherVotesRequired ===
+      fromCommitment.appAttributes.furtherVotesRequired - 1
+    )
+  ) {
+    throw new Error('Consensus App: furtherVotesRequired should be decremented by 1.');
+  }
+}
+function validConsensusState(commitment: AppCommitment) {
+  if (!(commitment.appAttributes.proposedAllocation.length === 0)) {
+    throw new Error("ConsensusApp: 'proposedAllocation' must be reset during consensus.");
+  }
+
+  if (!(commitment.appAttributes.proposedDestination.length === 0)) {
+    throw new Error("ConsensusApp: 'proposedDestination' must be reset during consensus.");
+  }
+}

--- a/packages/fmg-nitro-adjudicator/src/validTransition.ts
+++ b/packages/fmg-nitro-adjudicator/src/validTransition.ts
@@ -55,11 +55,16 @@ function validateVote(fromCommitment: AppCommitment, toCommitment: AppCommitment
   proposalsUnchanged(fromCommitment, toCommitment);
   furtherVotesRequiredDecremented(fromCommitment, toCommitment);
 }
+
 // helpers
+function areEqual(left: string[], right: string[]) {
+  // This is safe, as stringify behaves well on a flat array of strings
+  return JSON.stringify(left) === JSON.stringify(right);
+}
 function haveBalancesBeenUpdated(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
   return (
-    fromCommitment.appAttributes.proposedAllocation === toCommitment.allocation &&
-    fromCommitment.appAttributes.proposedDestination === toCommitment.destination
+    areEqual(fromCommitment.appAttributes.proposedAllocation, toCommitment.allocation) &&
+    areEqual(fromCommitment.appAttributes.proposedDestination, toCommitment.destination)
   );
 }
 function hasFurtherVotesNeededBeenInitialized(commitment: AppCommitment): boolean {
@@ -67,40 +72,39 @@ function hasFurtherVotesNeededBeenInitialized(commitment: AppCommitment): boolea
   return commitment.appAttributes.furtherVotesRequired === numParticipants - 1;
 }
 
-// modifiers
 function balancesUpdated(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  if (!(fromCommitment.appAttributes.proposedAllocation === toCommitment.allocation)) {
+  if (!areEqual(fromCommitment.appAttributes.proposedAllocation, toCommitment.allocation)) {
     throw new Error("ConsensusApp: 'allocation' must be set to the previous `proposedAllocation`.");
   }
 
-  if (!(fromCommitment.appAttributes.proposedDestination === toCommitment.destination)) {
+  if (!areEqual(fromCommitment.appAttributes.proposedDestination, toCommitment.destination)) {
     throw new Error(
       "ConsensusApp: 'destination' must be set to the previous `proposedDestination`",
     );
   }
 }
 function balancesUnchanged(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  if (!(fromCommitment.allocation === toCommitment.allocation)) {
+  if (!areEqual(fromCommitment.allocation, toCommitment.allocation)) {
     throw new Error("ConsensusApp: 'allocation' must be the same between commitments.");
   }
 
-  if (!(fromCommitment.destination === toCommitment.destination)) {
+  if (!areEqual(fromCommitment.destination, toCommitment.destination)) {
     throw new Error("ConsensusApp: 'destination' must be the same between commitments.");
   }
 }
 function proposalsUnchanged(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
   if (
-    !(
-      fromCommitment.appAttributes.proposedAllocation ===
-      toCommitment.appAttributes.proposedAllocation
+    !areEqual(
+      fromCommitment.appAttributes.proposedAllocation,
+      toCommitment.appAttributes.proposedAllocation,
     )
   ) {
     throw new Error("ConsensusApp: 'proposedAllocation' must be the same between commitments.");
   }
   if (
-    !(
-      fromCommitment.appAttributes.proposedDestination ===
-      toCommitment.appAttributes.proposedDestination
+    !areEqual(
+      fromCommitment.appAttributes.proposedDestination,
+      toCommitment.appAttributes.proposedDestination,
     )
   ) {
     throw new Error("ConsensusApp: 'proposedDestination' must be the same between commitments.");

--- a/packages/fmg-nitro-adjudicator/src/validTransition.ts
+++ b/packages/fmg-nitro-adjudicator/src/validTransition.ts
@@ -1,6 +1,14 @@
-import { AppCommitment, isConsensusReached, isProposal } from './consensus-app';
+import { AppCommitment, isConsensusReached, isProposal, UpdateType } from './consensus-app';
 export function validTransition(fromCommitment: AppCommitment, toCommitment: AppCommitment): true {
-  // State; machine; transition; identifier;
+  // Commitment validation
+
+  if (toCommitment.appAttributes.updateType === UpdateType.Proposal) {
+    validProposeCommitment(toCommitment);
+  } else if (toCommitment.appAttributes.updateType === UpdateType.Consensus) {
+    validConsensusCommitment(toCommitment);
+  }
+
+  // State machine transition identifier
   if (isConsensusReached(fromCommitment)) {
     if (isProposal(toCommitment)) {
       validatePropose(fromCommitment, toCommitment);
@@ -35,21 +43,17 @@ export function validTransition(fromCommitment: AppCommitment, toCommitment: App
 }
 
 function validatePass(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  validProposeCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
   proposalsUnchanged(fromCommitment, toCommitment);
 }
 function validatePropose(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  validProposeCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
   furtherVotesRequiredInitialized(toCommitment);
 }
 function validateFinalVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  validConsensusCommitment(toCommitment);
   balancesUpdated(fromCommitment, toCommitment);
 }
 function validateVeto(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  validConsensusCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
 }
 function validateVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {

--- a/packages/fmg-nitro-adjudicator/src/validTransition.ts
+++ b/packages/fmg-nitro-adjudicator/src/validTransition.ts
@@ -43,12 +43,12 @@ function validatePropose(fromCommitment: AppCommitment, toCommitment: AppCommitm
   furtherVotesRequiredInitialized(toCommitment);
 }
 function validateFinalVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
-  validConsensusState(toCommitment);
+  validConsensusCommitment(toCommitment);
   balancesUpdated(fromCommitment, toCommitment);
 }
 function validateVeto(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  validConsensusCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
-  validConsensusState(toCommitment);
 }
 function validateVote(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
   balancesUnchanged(fromCommitment, toCommitment);
@@ -131,7 +131,12 @@ function furtherVotesRequiredDecremented(
     throw new Error('Consensus App: furtherVotesRequired should be decremented by 1.');
   }
 }
-function validConsensusState(commitment: AppCommitment) {
+
+function validConsensusCommitment(commitment: AppCommitment) {
+  if (commitment.appAttributes.furtherVotesRequired !== 0) {
+    throw new Error("ConsensusApp: 'furtherVotesRequired' must be zero during consensus.");
+  }
+
   if (!(commitment.appAttributes.proposedAllocation.length === 0)) {
     throw new Error("ConsensusApp: 'proposedAllocation' must be reset during consensus.");
   }

--- a/packages/fmg-nitro-adjudicator/src/validTransition.ts
+++ b/packages/fmg-nitro-adjudicator/src/validTransition.ts
@@ -35,10 +35,12 @@ export function validTransition(fromCommitment: AppCommitment, toCommitment: App
 }
 
 function validatePass(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  validProposeCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
   proposalsUnchanged(fromCommitment, toCommitment);
 }
 function validatePropose(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+  validProposeCommitment(toCommitment);
   balancesUnchanged(fromCommitment, toCommitment);
   furtherVotesRequiredInitialized(toCommitment);
 }
@@ -133,6 +135,20 @@ function furtherVotesRequiredDecremented(
 }
 
 function validConsensusCommitment(commitment: AppCommitment) {
+  if (commitment.appAttributes.furtherVotesRequired !== 0) {
+    throw new Error("ConsensusApp: 'furtherVotesRequired' must be zero during consensus.");
+  }
+
+  if (!(commitment.appAttributes.proposedAllocation.length === 0)) {
+    throw new Error("ConsensusApp: 'proposedAllocation' must be reset during consensus.");
+  }
+
+  if (!(commitment.appAttributes.proposedDestination.length === 0)) {
+    throw new Error("ConsensusApp: 'proposedDestination' must be reset during consensus.");
+  }
+}
+
+function validProposeCommitment(commitment: AppCommitment) {
   if (commitment.appAttributes.furtherVotesRequired !== 0) {
     throw new Error("ConsensusApp: 'furtherVotesRequired' must be zero during consensus.");
   }

--- a/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
@@ -74,6 +74,18 @@ describe('ConsensusApp', () => {
     await setupContracts();
   });
 
+  describe('validConsensusCommitment', () => {
+    const fromCommitment = oneVoteComplete;
+    const toCommitment = finalVote(fromCommitment);
+    itRevertsForAnInvalidConsensusCommitment(fromCommitment, toCommitment);
+  });
+
+  describe('validProposeCommitment', () => {
+    const fromCommitment = initialConsensus(defaults);
+    const toCommitment = propose(fromCommitment, proposedAllocation, proposedDestination);
+    itRevertsForAnInvalidProposeCommitment(fromCommitment, toCommitment);
+  });
+
   describe('the propose transition', async () => {
     const fromCommitment = initialConsensus(defaults);
     const toCommitment = propose(fromCommitment, proposedAllocation, proposedDestination);
@@ -134,7 +146,6 @@ describe('ConsensusApp', () => {
     const toCommitment = finalVote(fromCommitment);
 
     itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
-    itRevertsForAnInvalidConsensusState(fromCommitment, toCommitment);
     itRevertsWhenTheBalancesAreNotUpdated(fromCommitment, toCommitment);
   });
 
@@ -145,7 +156,6 @@ describe('ConsensusApp', () => {
 
     itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
     itRevertsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
-    itRevertsForAnInvalidConsensusState(fromCommitment, toCommitment);
   });
 
   // Helper functions
@@ -216,7 +226,21 @@ describe('ConsensusApp', () => {
     });
   }
 
-  function itRevertsForAnInvalidConsensusState(fromCommitmentArgs, toCommitmentArgs) {
+  function itRevertsForAnInvalidConsensusCommitment(fromCommitmentArgs, toCommitmentArgs) {
+    it('reverts when the furtherVotesRequired is not zero', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        furtherVotesRequired: 1,
+      });
+
+      await invalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'furtherVotesRequired' must be 0 during consensus.",
+      );
+    });
+
     it('reverts when the proposedAllocation is not empty', async () => {
       const fromCommitment = appCommitment(fromCommitmentArgs);
 
@@ -242,6 +266,51 @@ describe('ConsensusApp', () => {
         fromCommitment,
         toCommitmentAllocation,
         "ConsensusApp: 'proposedDestination' must be reset during consensus.",
+      );
+    });
+  }
+
+  function itRevertsForAnInvalidProposeCommitment(fromCommitmentArgs, toCommitmentArgs) {
+    it('reverts when the furtherVotesRequired is zero', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        furtherVotesRequired: 1,
+      });
+
+      await invalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'proposedDestination' must be zero during propose.",
+      );
+    });
+
+    it('reverts when the proposedAllocation is empty', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        proposedAllocation: [],
+      });
+
+      await invalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'proposedAllocation' must not be empty during propose.",
+      );
+    });
+
+    it('reverts when the proposedDestination and proposedAllocation are not the same length', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        proposedAllocation,
+        proposedDestination: participants,
+      });
+
+      await invalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'proposedDestination' and 'proposedAllocation' must be the same length during propose.",
       );
     });
   }

--- a/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { getNetworkId, getGanacheProvider, expectRevert, delay } from 'magmo-devtools';
-import { Channel, ethereumArgs, toUint256, Commitment, CommitmentType } from 'fmg-core';
+import { Channel, ethereumArgs, toUint256, CommitmentType } from 'fmg-core';
 
 import ConsensusAppArtifact from '../build/contracts/ConsensusApp.json';
 

--- a/packages/fmg-nitro-adjudicator/test/consensus-app.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-app.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { Channel, toUint256, CommitmentType } from 'fmg-core';
+import { Channel, toUint256, CommitmentType, Commitment } from 'fmg-core';
 
 import {
   propose,
@@ -43,6 +43,10 @@ describe('ConsensusApp', () => {
     commitmentCount: 0,
   };
 
+  function copy(c) {
+    return JSON.parse(JSON.stringify(c));
+  }
+
   const oneVoteComplete = propose(
     initialConsensus(defaults),
     proposedAllocation,
@@ -54,7 +58,7 @@ describe('ConsensusApp', () => {
 
   describe('the propose transition', async () => {
     const fromCommitment = initialConsensus(defaults);
-    const toCommitment = propose(fromCommitment, proposedAllocation, proposedDestination);
+    const toCommitment = propose(copy(fromCommitment), proposedAllocation, proposedDestination);
     it('returns true on a valid transition', async () => {
       expectValidTransition(fromCommitment, toCommitment);
     });
@@ -65,7 +69,7 @@ describe('ConsensusApp', () => {
 
   describe('the pass transition', async () => {
     const fromCommitment = initialConsensus(defaults);
-    const toCommitment = pass(fromCommitment);
+    const toCommitment = pass(copy(fromCommitment));
 
     it('returns true on a valid transition', async () => {
       expectValidTransition(fromCommitment, toCommitment);
@@ -82,7 +86,7 @@ describe('ConsensusApp', () => {
     const alternativeProposedAllocation = [toUint256(6)];
 
     const toCommitment = proposeAlternative(
-      fromCommitment,
+      copy(fromCommitment),
       alternativeProposedAllocation,
       alternativeProposedDestination,
     );
@@ -99,7 +103,7 @@ describe('ConsensusApp', () => {
 
   describe('the vote transition', async () => {
     const fromCommitment = oneVoteComplete;
-    const toCommitment = vote(fromCommitment);
+    const toCommitment = vote(copy(fromCommitment));
 
     itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
     itThrowsWhenFurtherVotesRequiredIsNotDecremented(fromCommitment, toCommitment);
@@ -109,7 +113,7 @@ describe('ConsensusApp', () => {
 
   describe('the final vote transition', async () => {
     const fromCommitment = twoVotesComplete;
-    const toCommitment = finalVote(fromCommitment);
+    const toCommitment = finalVote(copy(fromCommitment));
 
     itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
     itThrowsForAnInvalidConsensusState(fromCommitment, toCommitment);
@@ -119,7 +123,7 @@ describe('ConsensusApp', () => {
   describe('the veto transition', async () => {
     const fromCommitment = oneVoteComplete;
 
-    const toCommitment = veto(fromCommitment);
+    const toCommitment = veto(copy(fromCommitment));
 
     itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
     itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
@@ -175,7 +179,7 @@ describe('ConsensusApp', () => {
   function itReturnsTrueOnAValidTransition(fromCommitmentArgs, toCommitmentArgs) {
     it('returns true when the commitment is valid', async () => {
       const fromCommitment = appCommitment(fromCommitmentArgs);
-      const toCommitment = appCommitment(toCommitmentArgs);
+      const toCommitment = appCommitment(copy(toCommitmentArgs));
 
       expectValidTransition(fromCommitment, toCommitment);
     });
@@ -185,7 +189,7 @@ describe('ConsensusApp', () => {
     it('throws when the proposedAllocation is not empty', async () => {
       const fromCommitment = appCommitment(fromCommitmentArgs);
 
-      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+      const toCommitmentAllocation = appCommitment(copy(toCommitmentArgs), {
         proposedAllocation: allocation,
       });
 
@@ -199,7 +203,7 @@ describe('ConsensusApp', () => {
     it('throws when the proposedDestination is not empty', async () => {
       const fromCommitment = appCommitment(fromCommitmentArgs);
 
-      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+      const toCommitmentAllocation = appCommitment(copy(toCommitmentArgs), {
         proposedDestination: participants,
       });
 
@@ -213,7 +217,7 @@ describe('ConsensusApp', () => {
 
   function itThrowsWhenFurtherVotesRequiredIsNotIntialized(fromCommitmentArgs, toCommitmentArgs) {
     it('throws when further votes requires is not initialized properly', async () => {
-      const toCommitment = appCommitment(toCommitmentArgs, { furtherVotesRequired: 0 });
+      const toCommitment = appCommitment(copy(toCommitmentArgs), { furtherVotesRequired: 0 });
       expectInvalidTransition(
         fromCommitmentArgs,
         toCommitment,
@@ -224,7 +228,7 @@ describe('ConsensusApp', () => {
 
   function itThrowsWhenFurtherVotesRequiredIsNotDecremented(fromCommitmentArgs, toCommitmentArgs) {
     it('throws when further votes requires is not decremented properly', async () => {
-      const toCommitment = appCommitment(toCommitmentArgs, { furtherVotesRequired: 0 });
+      const toCommitment = appCommitment(copy(toCommitmentArgs), { furtherVotesRequired: 0 });
       expectInvalidTransition(
         fromCommitmentArgs,
         toCommitment,
@@ -279,7 +283,7 @@ describe('ConsensusApp', () => {
 
   function itThrowsWhenTheProposalsAreChanged(fromCommitmentArgs, toCommitmentArgs) {
     it('throws when the proposedAllocation is changed', async () => {
-      const toCommitmentDifferentAllocation = appCommitment(toCommitmentArgs, {
+      const toCommitmentDifferentAllocation = appCommitment(copy(toCommitmentArgs), {
         proposedAllocation: allocation,
       });
 
@@ -290,7 +294,7 @@ describe('ConsensusApp', () => {
       );
     });
     it('throws when the proposedDestination is changed', async () => {
-      const toCommitmentDifferentDestination = appCommitment(toCommitmentArgs, {
+      const toCommitmentDifferentDestination = appCommitment(copy(toCommitmentArgs), {
         proposedDestination: participants,
       });
 

--- a/packages/fmg-nitro-adjudicator/test/consensus-app.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-app.test.ts
@@ -1,0 +1,304 @@
+import { ethers } from 'ethers';
+import { Channel, toUint256, CommitmentType } from 'fmg-core';
+
+import {
+  propose,
+  initialConsensus,
+  pass,
+  proposeAlternative,
+  vote,
+  ConsensusBaseCommitment,
+  finalVote,
+  veto,
+  AppCommitment,
+  UpdateType,
+  AppAttributes,
+} from '../src/consensus-app';
+import { validTransition } from '../src/validTransition';
+
+describe('ConsensusApp', () => {
+  const participantA = new ethers.Wallet(
+    '6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
+  );
+  const participantB = new ethers.Wallet(
+    '6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c',
+  );
+  const participantC = new ethers.Wallet(
+    '5e1b32fb763f62e1d19a9c9cd8c5417bd31b7d697ee018a8afe3cac2292fdd3e',
+  );
+  const participants = [participantA.address, participantB.address, participantC.address];
+  const proposedDestination = [participantA.address, participantB.address];
+
+  const allocation = [toUint256(1), toUint256(2), toUint256(3)];
+  const proposedAllocation = [toUint256(4), toUint256(2)];
+
+  const channel: Channel = { channelType: participantB.address, nonce: 0, participants }; // just use any valid address
+  const defaults = {
+    channel,
+    allocation,
+    destination: participants,
+    turnNum: 6,
+    proposedDestination,
+    proposedAllocation,
+    commitmentCount: 0,
+  };
+
+  const oneVoteComplete = propose(
+    initialConsensus(defaults),
+    proposedAllocation,
+    proposedDestination,
+  );
+  const twoVotesComplete = vote(
+    propose(initialConsensus(defaults), proposedAllocation, proposedDestination),
+  );
+
+  describe('the propose transition', async () => {
+    const fromCommitment = initialConsensus(defaults);
+    const toCommitment = propose(fromCommitment, proposedAllocation, proposedDestination);
+    it('returns true on a valid transition', async () => {
+      expectValidTransition(fromCommitment, toCommitment);
+    });
+
+    itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
+    itThrowsWhenFurtherVotesRequiredIsNotIntialized(fromCommitment, toCommitment);
+  });
+
+  describe('the pass transition', async () => {
+    const fromCommitment = initialConsensus(defaults);
+    const toCommitment = pass(fromCommitment);
+
+    it('returns true on a valid transition', async () => {
+      expectValidTransition(fromCommitment, toCommitment);
+    });
+
+    itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
+    itThrowsWhenTheProposalsAreChanged(fromCommitment, toCommitment);
+  });
+
+  describe('the propose alternative transition', async () => {
+    const fromCommitment = oneVoteComplete;
+
+    const alternativeProposedDestination = [participantA.address];
+    const alternativeProposedAllocation = [toUint256(6)];
+
+    const toCommitment = proposeAlternative(
+      fromCommitment,
+      alternativeProposedAllocation,
+      alternativeProposedDestination,
+    );
+
+    itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
+    it('throws when the furtherVotesRequired is not re-initialized', async () => {
+      expectInvalidTransition(fromCommitment, {
+        ...toCommitment,
+        appAttributes: { ...toCommitment.appAttributes, furtherVotesRequired: 1 },
+      });
+    });
+    itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
+  });
+
+  describe('the vote transition', async () => {
+    const fromCommitment = oneVoteComplete;
+    const toCommitment = vote(fromCommitment);
+
+    itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
+    itThrowsWhenFurtherVotesRequiredIsNotDecremented(fromCommitment, toCommitment);
+    itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
+    itThrowsWhenTheProposalsAreChanged(fromCommitment, toCommitment);
+  });
+
+  describe('the final vote transition', async () => {
+    const fromCommitment = twoVotesComplete;
+    const toCommitment = finalVote(fromCommitment);
+
+    itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
+    itThrowsForAnInvalidConsensusState(fromCommitment, toCommitment);
+    itThrowsWhenTheBalancesAreNotUpdated(fromCommitment, toCommitment);
+  });
+
+  describe('the veto transition', async () => {
+    const fromCommitment = oneVoteComplete;
+
+    const toCommitment = veto(fromCommitment);
+
+    itReturnsTrueOnAValidTransition(fromCommitment, toCommitment);
+    itThrowsWhenTheBalancesAreChanged(fromCommitment, toCommitment);
+    itThrowsForAnInvalidConsensusState(fromCommitment, toCommitment);
+  });
+
+  // Helper functions
+
+  function appCommitment(
+    c: ConsensusBaseCommitment,
+    attrs?: Partial<AppAttributes>,
+  ): AppCommitment {
+    switch (c.appAttributes.updateType) {
+      case UpdateType.Proposal:
+        return {
+          ...c,
+          commitmentType: CommitmentType.App,
+          appAttributes: {
+            ...c.appAttributes,
+            ...attrs,
+            updateType: UpdateType.Proposal,
+          },
+        };
+      case UpdateType.Consensus:
+        return {
+          ...c,
+          commitmentType: CommitmentType.App,
+          appAttributes: {
+            ...c.appAttributes,
+            ...attrs,
+            updateType: UpdateType.Consensus,
+          },
+        };
+    }
+  }
+
+  function expectInvalidTransition(
+    fromCommitment: AppCommitment,
+    toCommitment: AppCommitment,
+    error?,
+  ) {
+    if (error) {
+      expect(() => validTransition(fromCommitment, toCommitment)).toThrowError(error);
+    } else {
+      expect(() => validTransition(fromCommitment, toCommitment)).toThrowError();
+    }
+  }
+
+  function expectValidTransition(fromCommitment: AppCommitment, toCommitment: AppCommitment) {
+    expect(validTransition(fromCommitment, toCommitment)).toBe(true);
+  }
+
+  function itReturnsTrueOnAValidTransition(fromCommitmentArgs, toCommitmentArgs) {
+    it('returns true when the commitment is valid', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+      const toCommitment = appCommitment(toCommitmentArgs);
+
+      expectValidTransition(fromCommitment, toCommitment);
+    });
+  }
+
+  function itThrowsForAnInvalidConsensusState(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when the proposedAllocation is not empty', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        proposedAllocation: allocation,
+      });
+
+      expectInvalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'proposedAllocation' must be reset during consensus.",
+      );
+    });
+
+    it('throws when the proposedDestination is not empty', async () => {
+      const fromCommitment = appCommitment(fromCommitmentArgs);
+
+      const toCommitmentAllocation = appCommitment(toCommitmentArgs, {
+        proposedDestination: participants,
+      });
+
+      expectInvalidTransition(
+        fromCommitment,
+        toCommitmentAllocation,
+        "ConsensusApp: 'proposedDestination' must be reset during consensus.",
+      );
+    });
+  }
+
+  function itThrowsWhenFurtherVotesRequiredIsNotIntialized(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when further votes requires is not initialized properly', async () => {
+      const toCommitment = appCommitment(toCommitmentArgs, { furtherVotesRequired: 0 });
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitment,
+        'Consensus App: furtherVotesRequired needs to be initialized to the correct value.',
+      );
+    });
+  }
+
+  function itThrowsWhenFurtherVotesRequiredIsNotDecremented(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when further votes requires is not decremented properly', async () => {
+      const toCommitment = appCommitment(toCommitmentArgs, { furtherVotesRequired: 0 });
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitment,
+        'Consensus App: furtherVotesRequired should be decremented by 1',
+      );
+    });
+  }
+
+  function itThrowsWhenTheBalancesAreNotUpdated(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when the allocation is not updated', async () => {
+      const toCommitmentDifferentAllocation = appCommitment({
+        ...toCommitmentArgs,
+        allocation,
+      });
+      expectInvalidTransition(fromCommitmentArgs, toCommitmentDifferentAllocation);
+    });
+    it('throws when the destination is not updated', async () => {
+      const toCommitmentDifferentDestination = appCommitment({
+        ...toCommitmentArgs,
+        destination: participants,
+      });
+      expectInvalidTransition(fromCommitmentArgs, toCommitmentDifferentDestination);
+    });
+  }
+
+  function itThrowsWhenTheBalancesAreChanged(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when the allocation is changed', async () => {
+      const toCommitmentDifferentAllocation = appCommitment({
+        ...toCommitmentArgs,
+        allocation: proposedAllocation,
+      });
+
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitmentDifferentAllocation,
+        "ConsensusApp: 'allocation' must be the same between ",
+      );
+    });
+    it('throws when the destination is changed', async () => {
+      const toCommitmentDifferentDestination = appCommitment({
+        ...toCommitmentArgs,
+        destination: proposedDestination,
+      });
+
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitmentDifferentDestination,
+        "ConsensusApp: 'destination' must be the same between ",
+      );
+    });
+  }
+
+  function itThrowsWhenTheProposalsAreChanged(fromCommitmentArgs, toCommitmentArgs) {
+    it('throws when the proposedAllocation is changed', async () => {
+      const toCommitmentDifferentAllocation = appCommitment(toCommitmentArgs, {
+        proposedAllocation: allocation,
+      });
+
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitmentDifferentAllocation,
+        "ConsensusApp: 'proposedAllocation' must be the same between ",
+      );
+    });
+    it('throws when the proposedDestination is changed', async () => {
+      const toCommitmentDifferentDestination = appCommitment(toCommitmentArgs, {
+        proposedDestination: participants,
+      });
+
+      expectInvalidTransition(
+        fromCommitmentArgs,
+        toCommitmentDifferentDestination,
+        "ConsensusApp: 'proposedDestination' must be the same between ",
+      );
+    });
+  }
+});


### PR DESCRIPTION
This PR has two goals:
1. a commitment now has an `appAttributes` property, rather than a flat set of properties.
2. A `validTransition` function is implemented in typescript.

Re (2), I simply ported the existing contract code and tests to Typescript.