### PR TITLE
Fix conclude method

### DIFF
--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -450,7 +450,7 @@ contract NitroAdjudicator {
         );
 
         outcomes[channelId] = Outcome(
-            proof.penultimateCommitment.participants,
+            proof.penultimateCommitment.destination,
             now,
             proof.penultimateCommitment,
             outcomes[channelId].guaranteedChannel,

--- a/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
@@ -1084,7 +1084,7 @@ describe('nitroAdjudicator', () => {
         };
       });
 
-      it.only('works when the conclusion proof is valid', async () => {
+      it('works when the conclusion proof is valid', async () => {
         const {
           destination: startDestination,
           allocation: startAllocation,
@@ -1117,7 +1117,7 @@ describe('nitroAdjudicator', () => {
         // TODO: figure out how to test finalizedAt
       });
 
-      it.only('works when destination =/= participants', async () => {
+      it('works when destination =/= participants', async () => {
         const channelAlt = {
           ...channel,
         };


### PR DESCRIPTION
When registering a conclusion proof for a ledger channel, the `destination` field need not be the same as the `participants` field. 