### PR TITLE
Add optional guaranteedChannel to Channel

### DIFF
--- a/packages/fmg-core/contracts/Commitment.sol
+++ b/packages/fmg-core/contracts/Commitment.sol
@@ -8,6 +8,7 @@ library Commitment {
         address channelType;
         uint32 nonce;
         address[] participants;
+        address guaranteedChannel;
         uint8 commitmentType;
         uint32 turnNum;
         uint32 commitmentCount;
@@ -34,7 +35,12 @@ library Commitment {
 
     function channelId(CommitmentStruct memory _commitment) public pure returns (address) {
         bytes32 h = keccak256(
-            abi.encodePacked(_commitment.channelType, _commitment.nonce, _commitment.participants)
+            abi.encodePacked(
+                _commitment.channelType,
+                _commitment.nonce,
+                _commitment.participants,
+                _commitment.guaranteedChannel
+            )
         );
         address addr;
         assembly {

--- a/packages/fmg-core/contracts/Rules.sol
+++ b/packages/fmg-core/contracts/Rules.sol
@@ -148,6 +148,15 @@ library Rules {
         Commitment.CommitmentStruct memory _fromCommitment,
         Commitment.CommitmentStruct memory _toCommitment
     ) public pure returns (bool) {
+        require(
+            Commitment.allocationsEqual(_fromCommitment, _toCommitment),
+            "Invalid transition from PreFundSetup: allocations must be equal"
+        );
+        require(
+            Commitment.destinationsEqual(_fromCommitment, _toCommitment),
+            "Invalid transition from PreFundSetup: destinations must be equal"
+        );
+
         if (_fromCommitment.commitmentCount == _fromCommitment.participants.length - 1) {
             // there are two options from the final PreFundSetup Commitment
             // 1. PreFundSetup -> PostFundSetup transition
@@ -161,26 +170,10 @@ library Rules {
                     Commitment.appAttributesEqual(_fromCommitment, _toCommitment),
                     "Invalid transition from PreFundSetup: appAttributes must be equal"
                 );
-                require(
-                    Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PreFundSetup: allocations must be equal"
-                );
-                require(
-                    Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PreFundSetup: destinations must be equal"
-                );
             } else {
                 require(
                     _toCommitment.isConclude(),
                     "Invalid transition from PreFundSetup: commitmentType must be Conclude"
-                );
-                require(
-                    Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PreFundSetup: allocations must be equal"
-                );
-                require(
-                    Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PreFundSetup: destinations must be equal"
                 );
                 
             }
@@ -198,14 +191,6 @@ library Rules {
                 _toCommitment.commitmentCount == _fromCommitment.commitmentCount + 1,
                 "Invalid transition from PreFundSetup: commitmentCount must increase by 1"
             );
-            require(
-                Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                "Invalid transition from PreFundSetup: allocations must be equal"
-            );
-            require(
-                Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                "Invalid transition from PreFundSetup: destinations must be equal"
-            );
         }
         return true;
     }
@@ -214,6 +199,15 @@ library Rules {
         Commitment.CommitmentStruct memory  _fromCommitment,
         Commitment.CommitmentStruct memory _toCommitment
     ) public pure returns (bool) {
+        require(
+            Commitment.allocationsEqual(_fromCommitment, _toCommitment),
+            "Invalid transition from PostFundSetup: allocations must be equal"
+        );
+        require(
+            Commitment.destinationsEqual(_fromCommitment, _toCommitment),
+            "Invalid transition from PostFundSetup: destinations must be equal"
+        );
+
         if (_fromCommitment.commitmentCount == _fromCommitment.participants.length - 1) {
             if (_toCommitment.isApp()) {
                 require(
@@ -225,16 +219,6 @@ library Rules {
                     _toCommitment.isConclude(),
                     "Invalid transition from PostFundSetup: commitmentType must be Conclude"
                 );
-
-                require(
-                    Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: allocations must be equal"
-                );
-                require(
-                    Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: destinations must be equal"
-                );
-
                 require(
                     _toCommitment.commitmentCount == 0,
                     "Invalid transition from PostFundSetup: commitmentCount must be reset when transitioning to Conclude"
@@ -254,27 +238,11 @@ library Rules {
                     _toCommitment.commitmentCount == _fromCommitment.commitmentCount + 1,
                     "Invalid transition from PostFundSetup: commitmentCount must increase by 1"
                 );
-                require(
-                    Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: allocations must be equal"
-                );
-                require(
-                    Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: destinations must be equal"
-                );
             } else {
                 // PostFundSetup -> Conclude
                 require(
                     _toCommitment.isConclude(),
                     "Invalid transition from PostFundSetup: commitmentType must be Conclude"
-                );
-                require(
-                    Commitment.allocationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: allocations must be equal"
-                );
-                require(
-                    Commitment.destinationsEqual(_fromCommitment, _toCommitment),
-                    "Invalid transition from PostFundSetup: destinations must be equal"
                 );
             }
         }

--- a/packages/fmg-core/src/channel.ts
+++ b/packages/fmg-core/src/channel.ts
@@ -5,6 +5,7 @@ export interface Channel {
   channelType: Address;
   nonce: Uint32;
   participants: Address[];
+  guaranteedChannel: Address;
 }
 
 export function channelID(channel: Channel) {
@@ -14,6 +15,7 @@ export function channelID(channel: Channel) {
       { type: 'address', value: channel.channelType },
       { type: 'uint32', value: channel.nonce },
       { type: 'address[]', value: channel.participants },
+      { type: 'address', value: channel.guaranteedChannel },
     ).slice(26);
   return toChecksumAddress(lowercaseID);
 }

--- a/packages/fmg-core/src/channel.ts
+++ b/packages/fmg-core/src/channel.ts
@@ -1,11 +1,12 @@
 import { soliditySha3, toChecksumAddress } from 'web3-utils';
 import { Address, Uint32 } from './types';
+import { ADDRESS_ZERO } from '.';
 
 export interface Channel {
   channelType: Address;
   nonce: Uint32;
   participants: Address[];
-  guaranteedChannel: Address;
+  guaranteedChannel?: Address;
 }
 
 export function channelID(channel: Channel) {
@@ -15,7 +16,7 @@ export function channelID(channel: Channel) {
       { type: 'address', value: channel.channelType },
       { type: 'uint32', value: channel.nonce },
       { type: 'address[]', value: channel.participants },
-      { type: 'address', value: channel.guaranteedChannel },
+      { type: 'address', value: channel.guaranteedChannel || ADDRESS_ZERO },
     ).slice(26);
   return toChecksumAddress(lowercaseID);
 }

--- a/packages/fmg-core/src/commitment.ts
+++ b/packages/fmg-core/src/commitment.ts
@@ -8,6 +8,7 @@ const SolidityCommitmentType = {
     channelType: 'address',
     nonce: 'uint32',
     participants: 'address[]',
+    guaranteedChannel: 'address',
     commitmentType: 'uint8',
     turnNum: 'uint32',
     commitmentCount: 'uint32',
@@ -40,19 +41,24 @@ export function fromHex(commitment: string): Commitment {
 }
 
 export function fromParameters(parameters: any[]): Commitment {
+  let idx = -1;
+  // Incrementing the idx variable works as long as the parameters are parsed in the
+  // same order as the commitment struct defines them
   const channel = {
-    channelType: parameters[0],
-    nonce: Number.parseInt(parameters[1], 10),
-    participants: parameters[2],
+    channelType: parameters[(idx += 1)],
+    nonce: Number.parseInt(parameters[(idx += 1)], 10),
+    participants: parameters[(idx += 1)],
+    guaranteedChannel: parameters[(idx += 1)],
   };
+
   return {
     channel,
-    commitmentType: Number.parseInt(parameters[3], 10) as CommitmentType,
-    turnNum: Number.parseInt(parameters[4], 10),
-    commitmentCount: Number.parseInt(parameters[5], 10),
-    destination: parameters[6],
-    allocation: parameters[7].map(a => bigNumberify(a).toHexString()),
-    appAttributes: parameters[8],
+    commitmentType: Number.parseInt(parameters[(idx += 1)], 10) as CommitmentType,
+    turnNum: Number.parseInt(parameters[(idx += 1)], 10),
+    commitmentCount: Number.parseInt(parameters[(idx += 1)], 10),
+    destination: parameters[(idx += 1)],
+    allocation: parameters[(idx += 1)].map(a => bigNumberify(a).toHexString()),
+    appAttributes: parameters[(idx += 1)],
   };
 }
 
@@ -67,6 +73,7 @@ export function ethereumArgs(commitment: Commitment) {
     commitment.channel.channelType,
     commitment.channel.nonce,
     commitment.channel.participants,
+    commitment.channel.guaranteedChannel,
     commitment.commitmentType,
     commitment.turnNum,
     commitment.commitmentCount,
@@ -81,6 +88,7 @@ export function asEthersObject(commitment: Commitment) {
     channelType: commitment.channel.channelType,
     nonce: commitment.channel.nonce,
     participants: commitment.channel.participants,
+    guaranteedChannel: commitment.channel.guaranteedChannel,
     commitmentType: commitment.commitmentType,
     turnNum: commitment.turnNum,
     commitmentCount: commitment.commitmentCount,

--- a/packages/fmg-core/src/commitment.ts
+++ b/packages/fmg-core/src/commitment.ts
@@ -2,6 +2,7 @@ import { Channel } from './channel';
 import abi from 'web3-eth-abi';
 import { Uint32, Uint256, Address, Bytes } from './types';
 import { bigNumberify } from 'ethers/utils';
+import { ADDRESS_ZERO } from '.';
 
 const SolidityCommitmentType = {
   CommitmentStruct: {
@@ -73,7 +74,7 @@ export function ethereumArgs(commitment: Commitment) {
     commitment.channel.channelType,
     commitment.channel.nonce,
     commitment.channel.participants,
-    commitment.channel.guaranteedChannel,
+    commitment.channel.guaranteedChannel || ADDRESS_ZERO,
     commitment.commitmentType,
     commitment.turnNum,
     commitment.commitmentCount,
@@ -88,7 +89,7 @@ export function asEthersObject(commitment: Commitment) {
     channelType: commitment.channel.channelType,
     nonce: commitment.channel.nonce,
     participants: commitment.channel.participants,
-    guaranteedChannel: commitment.channel.guaranteedChannel,
+    guaranteedChannel: commitment.channel.guaranteedChannel || ADDRESS_ZERO,
     commitmentType: commitment.commitmentType,
     turnNum: commitment.turnNum,
     commitmentCount: commitment.commitmentCount,

--- a/packages/fmg-core/src/index.ts
+++ b/packages/fmg-core/src/index.ts
@@ -20,6 +20,7 @@ export {
 
 import * as CountingApp from './test-app/counting-app';
 export { CountingApp };
+export const ADDRESS_ZERO = '0x' + '0'.repeat(40);
 
 export { Signature, Address, Uint256, Uint32, Uint8, Bytes32, Bytes, Byte } from './types';
 export {

--- a/packages/fmg-core/src/test/commitment.contract.test.ts
+++ b/packages/fmg-core/src/test/commitment.contract.test.ts
@@ -36,7 +36,8 @@ describe('Commitment', () => {
   const allocation = [new BigNumber(5).toHexString(), new BigNumber(4).toHexString()];
 
   const destination = [participantA.address, participantB.address];
-  const channel: Channel = { channelType, nonce, participants };
+  const guaranteedChannel = participantA.address;
+  const channel: Channel = { channelType, nonce, participants, guaranteedChannel };
   const commitmentType = CommitmentType.PreFundSetup;
   const commitment: Commitment = {
     channel,

--- a/packages/fmg-core/src/test/commitment.test.ts
+++ b/packages/fmg-core/src/test/commitment.test.ts
@@ -19,10 +19,11 @@ describe('Commitment', () => {
     '6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c',
   );
   const participants = [participantA.address, participantB.address];
+  const guaranteedChannel = participantA.address;
   const allocation = [new BigNumber(5).toHexString(), new BigNumber(4).toHexString()];
 
   const destination = [participantA.address, participantB.address];
-  const channel: Channel = { channelType, nonce, participants };
+  const channel: Channel = { channelType, nonce, participants, guaranteedChannel };
   const commitmentType = CommitmentType.PreFundSetup;
   const commitment: Commitment = {
     channel,

--- a/packages/fmg-core/src/test/framework/transitions.test.ts
+++ b/packages/fmg-core/src/test/framework/transitions.test.ts
@@ -136,13 +136,25 @@ describe('Rules', () => {
       });
     });
 
-    it('allows a valid transition when the allocations are empty in a guarantor channel', async () => {
+    it('allows a valid transition when the allocations are empty', async () => {
       fromCommitment.allocation = [];
       toCommitment.allocation = [];
       fromCommitment.channel.guaranteedChannel = participantA.address;
       toCommitment.channel.guaranteedChannel = participantA.address;
 
       expect(await validTransition(fromCommitment, toCommitment)).toEqual(true);
+    });
+
+    it('rejects a transition when the allocations are not empty', async () => {
+      fromCommitment.allocation = [];
+      toCommitment.allocation = ['0x00'];
+      fromCommitment.channel.guaranteedChannel = participantA.address;
+      toCommitment.channel.guaranteedChannel = participantA.address;
+
+      await expectRevert(
+        () => validTransition(fromCommitment, toCommitment),
+        'Invalid transition: allocation must be empty in guarantor channel.',
+      );
     });
   });
 

--- a/packages/fmg-core/src/test/framework/transitions.test.ts
+++ b/packages/fmg-core/src/test/framework/transitions.test.ts
@@ -91,6 +91,61 @@ describe('Rules', () => {
     return await testFramework.validTransition(args(commitment1), args(commitment2));
   };
 
+  describe('ledger channels', () => {
+    beforeEach(() => {
+      fromCommitment = createCommitment.preFundSetup({
+        ...defaults,
+        turnNum: 0,
+        commitmentCount: 0,
+      });
+      toCommitment = createCommitment.preFundSetup({ ...defaults, turnNum: 1, commitmentCount: 1 });
+    });
+
+    it("rejects a transition where the destination and the allocation don't match in the fromCommitment", async () => {
+      fromCommitment.destination = fromCommitment.destination.slice(1);
+      expect.assertions(1);
+      await expectRevert(() => validTransition(fromCommitment, toCommitment));
+    });
+
+    it('rejects a transition where the allocation is empty', async () => {
+      fromCommitment.destination = fromCommitment.destination.slice(1);
+      expect.assertions(1);
+      await expectRevert(() => validTransition(fromCommitment, toCommitment));
+    });
+
+    it("rejects a transition where the destination and the allocation don't match in the toCommitment", async () => {
+      toCommitment.destination = toCommitment.destination.slice(1);
+      expect.assertions(1);
+      await expectRevert(() => validTransition(fromCommitment, toCommitment));
+    });
+  });
+
+  describe('guarantor channels', () => {
+    beforeEach(() => {
+      fromCommitment = createCommitment.preFundSetup({
+        ...defaults,
+        channel: { ...channel, guaranteedChannel: participantA.address },
+        allocation: [],
+        turnNum: 0,
+        commitmentCount: 0,
+      });
+      toCommitment = createCommitment.preFundSetup({
+        ...fromCommitment,
+        turnNum: 1,
+        commitmentCount: 1,
+      });
+    });
+
+    it('allows a valid transition when the allocations are empty in a guarantor channel', async () => {
+      fromCommitment.allocation = [];
+      toCommitment.allocation = [];
+      fromCommitment.channel.guaranteedChannel = participantA.address;
+      toCommitment.channel.guaranteedChannel = participantA.address;
+
+      expect(await validTransition(fromCommitment, toCommitment)).toEqual(true);
+    });
+  });
+
   describe('preFundSetup -> preFundSetup', () => {
     beforeEach(() => {
       fromCommitment = createCommitment.preFundSetup({

--- a/packages/fmg-core/src/test/framework/transitions.test.ts
+++ b/packages/fmg-core/src/test/framework/transitions.test.ts
@@ -13,6 +13,7 @@ import TestRulesArtifact from '../../../build/contracts/TestRules.json';
 
 import CountingCommitmentArtifact from '../../../build/contracts/CountingCommitment.json';
 import CountingAppArtifact from '../../../build/contracts/CountingApp.json';
+import { AddressZero } from 'ethers/constants';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
 const signer = provider.getSigner();
@@ -66,7 +67,8 @@ describe('Rules', () => {
       CountingAppArtifact.networks[networkId].address,
     );
 
-    otherChannel = { channelType: appContract.address, nonce: 1, participants };
+    const guaranteedChannel = AddressZero;
+    otherChannel = { channelType: appContract.address, nonce: 1, participants, guaranteedChannel };
 
     RulesArtifact.bytecode = linker.linkBytecode(RulesArtifact.bytecode, {
       Commitment: CommitmentArtifact.networks[networkId].address,
@@ -81,7 +83,7 @@ describe('Rules', () => {
     testFramework = await ContractFactory.fromSolidity(TestRulesArtifact, signer).deploy();
     // Contract setup --------------------------------------------------------------------------
 
-    channel = { channelType: appContract.address, nonce: 0, participants };
+    channel = { channelType: appContract.address, nonce: 0, participants, guaranteedChannel };
     defaults = { channel, allocation, destination, appCounter: 0 };
   });
 
@@ -147,6 +149,7 @@ describe('Rules', () => {
         commitmentCountMustIncrement('PreFundSetup'),
       );
     });
+
     it('rejects a transition where the app attributes changes', async () => {
       toCommitment.appCounter = 45;
       expect.assertions(1);

--- a/packages/fmg-core/src/test/test-app/counting-app.test.ts
+++ b/packages/fmg-core/src/test/test-app/counting-app.test.ts
@@ -42,8 +42,14 @@ describe('CountingApp', () => {
       '6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c',
     );
     const participants = [participantA.address, participantB.address];
+    const guaranteedChannel = participantA.address;
 
-    const channel: Channel = { channelType: app.address, nonce: 0, participants };
+    const channel: Channel = {
+      channelType: app.address,
+      nonce: 0,
+      participants,
+      guaranteedChannel,
+    };
     const numberToHexString = (value: number): string => {
       return utils.bigNumberify(value).toHexString();
     };

--- a/packages/fmg-core/src/test/test-app/counting-commitment.test.ts
+++ b/packages/fmg-core/src/test/test-app/counting-commitment.test.ts
@@ -53,8 +53,14 @@ describe('CountingCommitment', () => {
       '6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c',
     );
     const participants = [participantA.address, participantB.address];
+    const guaranteedChannel = participantA.address;
 
-    const channel: Channel = { channelType: participantB.address, nonce: 0, participants }; // just use any valid address
+    const channel: Channel = {
+      channelType: participantB.address,
+      nonce: 0,
+      participants,
+      guaranteedChannel,
+    }; // just use any valid address
 
     const defaults = {
       channel,

--- a/packages/fmg-core/src/test/utils.test.ts
+++ b/packages/fmg-core/src/test/utils.test.ts
@@ -24,7 +24,8 @@ describe('Commitment', () => {
   const allocation = [new BigNumber(5).toHexString(), new BigNumber(4).toHexString()];
 
   const destination = [participantA.address, participantB.address];
-  const channel: Channel = { channelType, nonce, participants };
+  const guaranteedChannel = participantA.address;
+  const channel: Channel = { channelType, nonce, participants, guaranteedChannel };
   const commitmentType = CommitmentType.PreFundSetup;
   const commitment: Commitment = {
     channel,

--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -290,21 +290,6 @@ contract NitroAdjudicator {
         require(
             Rules.validTransition(agreedCommitment, challengeCommitment)
         );
-        if (guaranteedChannel == zeroAddress) {
-            // If the guaranteeChannel is the zeroAddress, this outcome
-            // is an allocation
-            require(
-                agreedCommitment.allocation.length > 0,
-                "ForceMove: allocation outcome must have resolution"
-            );
-        } else {
-            // The non-zeroness of guaranteeChannel indicates that this outcome
-            // is a guarantee
-            require(
-                challengeCommitment.allocation.length == 0,
-                "ForceMove: guarantee outcome cannot have allocation"
-            );
-        }
 
         address channelId = agreedCommitment.channelId();
 

--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -27,7 +27,6 @@ contract NitroAdjudicator {
 
         // exactly one of the following two should be non-null
         // guarantee channels
-        address guaranteedChannel; // should be zero address in allocation channels
         uint[] allocation;         // should be zero length in guarantee channels
     }
 
@@ -139,7 +138,7 @@ contract NitroAdjudicator {
     function claim(address guarantor, address recipient, uint amount) public {
         Outcome memory guarantee = outcomes[guarantor];
         require(
-            guarantee.guaranteedChannel != zeroAddress,
+            guarantee.challengeCommitment.guaranteedChannel != zeroAddress,
             "Claim: a guarantee channel is required"
         );
         require(
@@ -148,11 +147,18 @@ contract NitroAdjudicator {
         );
 
         uint funding = holdings[guarantor];
-        Outcome memory reprioritizedOutcome = reprioritize(outcomes[guarantee.guaranteedChannel], guarantee);
+        Outcome memory reprioritizedOutcome = reprioritize(
+            outcomes[guarantee.challengeCommitment.guaranteedChannel],
+            guarantee
+        );
         if (affords(recipient, reprioritizedOutcome, funding) >= amount) {
-            outcomes[guarantee.guaranteedChannel] = reduce(outcomes[guarantee.guaranteedChannel], recipient, amount);
+            outcomes[guarantee.challengeCommitment.guaranteedChannel] = reduce(
+                outcomes[guarantee.challengeCommitment.guaranteedChannel],
+                recipient,
+                amount
+            );
             holdings[guarantor] = holdings[guarantor].sub(amount);
-            holdings[recipient] =  holdings[recipient].add(amount);
+            holdings[recipient] = holdings[recipient].add(amount);
         } else {
             revert('Claim: guarantor must be sufficiently funded');
         }
@@ -162,9 +168,12 @@ contract NitroAdjudicator {
     // Eth Management Logic
     // ********************
 
-    function reprioritize(Outcome memory allocation, Outcome memory guarantee) internal pure returns (Outcome memory) {
+    function reprioritize(
+        Outcome memory allocation,
+        Outcome memory guarantee
+    ) internal pure returns (Outcome memory) {
         require(
-            guarantee.guaranteedChannel != address(0),
+            guarantee.challengeCommitment.guaranteedChannel != address(0),
             "Claim: a guarantee channel is required"
         );
         address[] memory newDestination = new address[](guarantee.destination.length);
@@ -183,16 +192,20 @@ contract NitroAdjudicator {
             newDestination,
             allocation.finalizedAt,
             allocation.challengeCommitment,
-            zeroAddress,
             newAllocation
         );
     }
 
-    function affords(address recipient, Outcome memory outcome, uint funding) internal pure returns (uint256) {
+    function affords(
+        address recipient,
+        Outcome memory outcome,
+        uint funding
+    ) internal pure returns (uint256) {
         uint result = 0;
+        uint remainingFunding = funding;
 
         for (uint i = 0; i < outcome.destination.length; i++) {
-            if (funding <= 0) {
+            if (remainingFunding <= 0) {
                 break;
             }
 
@@ -200,28 +213,33 @@ contract NitroAdjudicator {
                 // It is technically allowed for a recipient to be listed in the
                 // outcome multiple times, so we must iterate through the entire
                 // array.
-                result =result.add(min(outcome.allocation[i], funding));
+                result = result.add(min(outcome.allocation[i], remainingFunding));
             }
-            if (funding > outcome.allocation[i]){
-                funding = funding.sub(outcome.allocation[i]);
+            if (remainingFunding > outcome.allocation[i]){
+                remainingFunding = remainingFunding.sub(outcome.allocation[i]);
             }else{
-                funding = 0;
+                remainingFunding = 0;
             }
         }
 
         return result;
     }
 
-    function reduce(Outcome memory outcome, address recipient, uint amount) internal pure returns (Outcome memory) { 
+    function reduce(
+        Outcome memory outcome,
+        address recipient,
+        uint amount
+    ) internal pure returns (Outcome memory) {
         uint256[] memory updatedAllocation = outcome.allocation;
         uint256 reduction = 0;
+        uint remainingAmount = amount;
         for (uint i = 0; i < outcome.destination.length; i++) {
             if (outcome.destination[i] == recipient) {
                 // It is technically allowed for a recipient to be listed in the
                 // outcome multiple times, so we must iterate through the entire
                 // array.
-                reduction = reduction.add(min(outcome.allocation[i], amount));
-                amount = amount.sub(reduction);
+                reduction = reduction.add(min(outcome.allocation[i], remainingAmount));
+                remainingAmount = remainingAmount.sub(reduction);
                 updatedAllocation[i] = updatedAllocation[i].sub(reduction);
             }
         }
@@ -229,8 +247,7 @@ contract NitroAdjudicator {
         return Outcome(
             outcome.destination,
             outcome.finalizedAt,
-            outcome.challengeCommitment, // Once the outcome is finalized, 
-            zeroAddress,
+            outcome.challengeCommitment, // Once the outcome is finalized,
             updatedAllocation
         );
     }
@@ -272,7 +289,6 @@ contract NitroAdjudicator {
     function forceMove(
         Commitment.CommitmentStruct memory agreedCommitment,
         Commitment.CommitmentStruct memory challengeCommitment,
-        address guaranteedChannel,
         Signature[] memory signatures
     ) public {
         require(
@@ -297,7 +313,6 @@ contract NitroAdjudicator {
             challengeCommitment.participants,
             now + CHALLENGE_DURATION,
             challengeCommitment,
-            guaranteedChannel,
             challengeCommitment.allocation
         );
 
@@ -332,7 +347,6 @@ contract NitroAdjudicator {
             outcomes[channel].destination,
             0,
             refutationCommitment,
-            outcomes[channel].guaranteedChannel,
             refutationCommitment.allocation
         );
         outcomes[channel] = updatedOutcome;
@@ -361,7 +375,6 @@ contract NitroAdjudicator {
             outcomes[channel].destination,
             0,
             responseCommitment,
-            outcomes[channel].guaranteedChannel,
             responseCommitment.allocation
         );
         outcomes[channel] = updatedOutcome;
@@ -417,7 +430,6 @@ contract NitroAdjudicator {
             outcomes[channel].destination,
             0,
             _responseCommitment,
-            outcomes[channel].guaranteedChannel,
             _responseCommitment.allocation
         );
         outcomes[channel] = updatedOutcome;
@@ -438,7 +450,6 @@ contract NitroAdjudicator {
             proof.penultimateCommitment.destination,
             now,
             proof.penultimateCommitment,
-            outcomes[channelId].guaranteedChannel,
             proof.penultimateCommitment.allocation
         );
         emit Concluded(channelId);

--- a/packages/fmg-nitro-adjudicator/contracts/test-contracts/TestNitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/test-contracts/TestNitroAdjudicator.sol
@@ -15,7 +15,7 @@ contract TestNitroAdjudicator is NitroAdjudicator {
         return affords(recipient, allocation, funding);
     }
 
-    function reducePub(Outcome memory allocation, address recipient, uint amount) public pure returns (Outcome memory) { 
+    function reducePub(Outcome memory allocation, address recipient, uint amount) public pure returns (Outcome memory) {
         return reduce(allocation, recipient, amount);
     }
 

--- a/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-app.contract.test.ts
@@ -58,7 +58,11 @@ describe('ConsensusApp', () => {
   const alternativeProposedDestination = [participantB.address, participantC.address];
   const alternativeProposedAllocation = [toUint256(4), toUint256(6)];
 
-  const channel: Channel = { channelType: participantB.address, nonce: 0, participants }; // just use any valid address
+  const channel: Channel = {
+    channelType: participantB.address,
+    nonce: 0,
+    participants,
+  }; // just use any valid address
   const defaults = {
     channel,
     allocation,

--- a/packages/fmg-nitro-adjudicator/test/consensus-commitment.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/consensus-commitment.test.ts
@@ -34,7 +34,11 @@ describe('ConsensusCommitment', () => {
   ];
   const proposedAllocation = [ethers.utils.bigNumberify(9).toHexString()];
 
-  const channel: Channel = { channelType: participantB.address, nonce: 0, participants }; // just use any valid address
+  const channel: Channel = {
+    channelType: participantB.address,
+    nonce: 0,
+    participants,
+  };
   const defaults = { channel, allocation, destination: participants };
   const commitment: Commitment = asCoreCommitment(
     propose(


### PR DESCRIPTION
A state channel might be a guarantor channel. In this case, it should be invariant throughout the lifetime of the state channel. This PR
- puts it in the `Channel` interface in typescript
- puts it on the `Commitment` struct in solidity
- pulls it off the `Outcome` struct
- removes it as an argument from some smart contract calls.

The rules are changed accordingly:
i) a guarantor channel must have an empty allocation
ii) a ledger channel cannot

This check was also on the `forceMove` method, and is removed from there.